### PR TITLE
Render console on start-up

### DIFF
--- a/client/Constellation.html
+++ b/client/Constellation.html
@@ -1,7 +1,3 @@
-<body>
-  {{> Constellation}}
-</body>
-
 <template name="Constellation">
   {{#if constellationActive}}
     <div id="Constellation" class="{{active}} Constellation {{constellationClass}}">

--- a/client/lib/setup.js
+++ b/client/lib/setup.js
@@ -147,4 +147,8 @@ Meteor.startup(function() {
     alert("Are you sure you the new field '" + field + "' is published?" + ((!Package["constellation:console-autopublish"]) ? "\n\nmeteor add constellation:console-autopublish\n\nwill allow you to switch autopublish on and off from the Constellation UI for easy checking." : "\n\nSwitch on autopublish to check."));
   });
   
+  Meteor.defer(function () {
+    Blaze.render(Template.Constellation, document.body);
+  });
+  
 });


### PR DESCRIPTION
Fixes #5.

I don't know if this is a React issue or if it's that you're not allowed to render multiple things separately in `<body>` but this seems to have fixed the issue.

**Edit**: Looks like I was able to confirm that this is something directly related to using React.

I had to use `Meteor.defer` also to make it render.
