### PR TITLE
Accounts fix

### DIFF
--- a/client/row_account/account.js
+++ b/client/row_account/account.js
@@ -1,7 +1,7 @@
 Template.Constellation_account_view.helpers({
   
   currentUserOrSwitchingAccount: function () {
-    return Package['accounts-base'] && Meteor.user() || ConstellationDict.get('Constellation_switchingAccount');
+    return (Package['accounts-base'] && Meteor.user()) || ConstellationDict.get('Constellation_switchingAccount');
   },
   accountCount: function () {
     return Meteor.users && Meteor.users.find().count();  

--- a/client/row_account/account.js
+++ b/client/row_account/account.js
@@ -1,7 +1,7 @@
 Template.Constellation_account_view.helpers({
   
   currentUserOrSwitchingAccount: function () {
-    return Meteor.user() || ConstellationDict.get('Constellation_switchingAccount');
+    return Package['accounts-base'] && Meteor.user() || ConstellationDict.get('Constellation_switchingAccount');
   },
   accountCount: function () {
     return Meteor.users && Meteor.users.find().count();  

--- a/client/row_collection/docControls.js
+++ b/client/row_collection/docControls.js
@@ -369,7 +369,7 @@ Template.Constellation_docControls.helpers({
     return Meteor.users && Meteor.users.find().count();  
   },
   currentUserOrSwitchingAccount: function () {
-    return Package['accounts-base'] && Meteor.user() || ConstellationDict.get('Constellation_switchingAccount');
+    return (Package['accounts-base'] && Meteor.user()) || ConstellationDict.get('Constellation_switchingAccount');
   },
   notEmpty: function () {
     var collectionName = String(this);

--- a/client/row_collection/docControls.js
+++ b/client/row_collection/docControls.js
@@ -369,7 +369,7 @@ Template.Constellation_docControls.helpers({
     return Meteor.users && Meteor.users.find().count();  
   },
   currentUserOrSwitchingAccount: function () {
-    return Meteor.user() || ConstellationDict.get('Constellation_switchingAccount');
+    return Package['accounts-base'] && Meteor.user() || ConstellationDict.get('Constellation_switchingAccount');
   },
   notEmpty: function () {
     var collectionName = String(this);


### PR DESCRIPTION
I'm developing a plugin and if I api.use/imply(constellation:console) from another package but don't have an accounts package also included in the app somewhere, an error is thrown at Meteor.user() on the two lines below. 

Added a check for accounts-base in the two spots I encountered.

There may be a better way to handle the missing package, but this eliminates the error, which is good enough for me. Another improvement could be to hide the accounts tab if accounts aren't used in the app.
