### PR TITLE
fixed typos in readme and a small issue with whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,27 +93,27 @@ var Constellation = Package["constellation:console"].API;
 ```
 then you can write:
 
-`Constellaton.isActive()` to check whether Constellation's UI is active or closed (i.e. has the user pressed __Control + C__ or not)
+`Constellation.isActive()` to check whether Constellation's UI is active or closed (i.e. has the user pressed __Control + C__ or not)
 
-`Constellaton.addTab({name: "my-plugin"})` to register a new tab called "my-plugin" in Constellation's UI - see above for the fields the object can have when adding a tab.
+`Constellation.addTab({name: "my-plugin"})` to register a new tab called "my-plugin" in Constellation's UI - see above for the fields the object can have when adding a tab.
 
 The `type` field/param in the three methods below will be:
  - `"collection"` for collection tabs
  - `"plugin"` for any tab added using `Constellation.addTab` - i.e. for tabs added by plugin packages and for the default tabs ("Fullscreen", "Account", "Actions", "Config")
 
-`Constellaton.getCurrentTab()` to get the `id` and type of the currently selected tab in an object of the form `{id: <tabId}, type: <tabType>}` (both values are strings)
+`Constellation.getCurrentTab()` to get the `id` and type of the currently selected tab in an object of the form `{id: <tabId}, type: <tabType>}` (both values are strings)
 
-`Constellaton.setCurrentTab("unique-id-of-my-tab", type)` to change tabs programatically (use either the `id` value set in `addTab({ ... })` or the `name` value if no `id` was set)
+`Constellation.setCurrentTab("unique-id-of-my-tab", type)` to change tabs programatically (use either the `id` value set in `addTab({ ... })` or the `name` value if no `id` was set)
 
-`Constellaton.isCurrentTab("unique-id-of-my-tab", type)` to check whether this is the current tab or not (returns `true` if you've passed the `id` of the current open tab, along with the correct `type`)
+`Constellation.isCurrentTab("unique-id-of-my-tab", type)` to check whether this is the current tab or not (returns `true` if you've passed the `id` of the current open tab, along with the correct `type`)
 
-`Constellaton.tabVisible("unique-id-of-my-tab", type)` to check if this tab is currently enabled by the user via the "Config ..." panel (i.e. does it currently appear as a tab in the user's UI)
+`Constellation.tabVisible("unique-id-of-my-tab", type)` to check if this tab is currently enabled by the user via the "Config ..." panel (i.e. does it currently appear as a tab in the user's UI)
 
 `Constellation.isFullScreen()` to see if Constellation is in fullscreen mode
 
-`Constellaton.hideCollection('collectionName')` to hide collections programatically (collections hidden this way cannot be unhidden through the "Config" tab - they won't even appear there) - accepts an array or a string
+`Constellation.hideCollection('collectionName')` to hide collections programatically (collections hidden this way cannot be unhidden through the "Config" tab - they won't even appear there) - accepts an array or a string
 
-`Constellaton.showCollection('collectionName')` to show collections programatically - accepts an array or a string
+`Constellation.showCollection('collectionName')` to show collections programatically - accepts an array or a string
 
 `Constellation.setKeyCode(keyCode)` to change the default toggle key from CTRL + C to CTRL + [whichever key's keycode you set] (Note: this should only be used in app code, as a last-resort config option, and not in plugin package code)
 
@@ -131,7 +131,7 @@ The `type` field/param in the three methods below will be:
 
 If you put a `callback` in your `addTab({ ... })` (e.g. `Constellation.addTab({name: "my-plugin", callback: "myCallBack", ...});`) you need to register it as follows:
 ```
-Constellaton.registerCallbacks({
+Constellation.registerCallbacks({
   "myCallBack" : function () {
     console.log("Callback fired!");
   }

--- a/client/Constellation.css
+++ b/client/Constellation.css
@@ -1,4 +1,4 @@
-#Constellation {  
+#Constellation {
   left: 0;
   bottom: 0;
   width: 100%;
@@ -42,8 +42,8 @@
   color: rgba(215,235,255,.8);
 }
 
-#Constellation ::-webkit-scrollbar { 
-    display: none; 
+#Constellation ::-webkit-scrollbar {
+    display: none;
 }
 
 #Constellation.Constellation_expand {
@@ -64,7 +64,7 @@
 }
 
 #Constellation.Constellation_fullscreen .Constellation_contentView {
-  height: 95%;    
+  height: 95%;
 }
 
 .Constellation_editable {
@@ -88,7 +88,7 @@
 #Constellation *, .Constellation_row {
   outline: none;
   font-family: Liberation Mono, Courier, Lucidatypewriter, Fixed, monospace !important;
-} 
+}
 
 #Constellation pre {
   outline: none;
@@ -118,7 +118,7 @@
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='$c1', endColorstr='$c2',GradientType=0);
   color: rgba(255, 255, 255, 0.6);
 }
-  
+
 .Constellation_row {
   padding: 0 8px;
   overflow: hidden;
@@ -156,6 +156,7 @@
   padding: 8px;
   line-height: 16px;
   font-size: 11px;
+  white-space: normal;
 }
 
 .Constellation_expand .ConstellationHide {
@@ -164,7 +165,7 @@
 
 .Constellation_row_expand {
   height: 320px;
-  cursor: default !important; 
+  cursor: default !important;
 }
 .Constellation_row_expand .Constellation_contentView {
   box-shadow: 0 0 0 80px rgba(0,0,0,.68);
@@ -201,7 +202,7 @@
   float: right;
 }
 
-.Constellation_header { 
+.Constellation_header {
   color: rgba(255,255,255,.6);
 }
 
@@ -264,7 +265,7 @@
   z-index: 9999999998;
   position: relative;
   transition: 0.3s;
-  color: rgba(255,255,255,.5); 
+  color: rgba(255,255,255,.5);
 }
 
 .Constellation_documentViewer pre {
@@ -324,7 +325,7 @@
 .Constellation_null {
   color: #AE81FF !important;
 }
-  
+
 /* red */
 .Constellation_key {
   color: #F92772 !important;
@@ -334,7 +335,7 @@
   line-height: 28px;
   height: 28px;
   border-radius: 5px 5px 0 0;
-  
+
   color: rgba(255, 255, 255, 0.6);
   padding-bottom: 1px;
 
@@ -443,7 +444,7 @@
 .Constellation_m_wrapper_expand {
   max-width: 100%;
 }
-  
+
 .Constellation_m_wrapper_expand .Constellation_m_edit {
   background: transparent;
   cursor: default;
@@ -525,11 +526,11 @@
 
 .Constellation_action_time {
   color: grey;
-  font-size: smaller;    
+  font-size: smaller;
 }
 
 .Constellation_action_toggle {
-  font-size: smaller;    
+  font-size: smaller;
 }
 
 .Constellation_installed_tabs {
@@ -539,7 +540,7 @@
 }
 
 .Constellation_installed_tabs li {
-  margin: 0;    
+  margin: 0;
 }
 
 .Constellation_installed_tabs li label{
@@ -572,7 +573,7 @@
 
 .Constellation_search_button_container {
   position: relative;
-  display: inline-block;    
+  display: inline-block;
 }
 
 .Constellation_search_button {
@@ -622,5 +623,5 @@
 }
 
 #Constellation select {
-  margin: 0;    
+  margin: 0;
 }


### PR DESCRIPTION
There were a few typos in the readme file (`Constellaton` instead of `Constellation`).

In addition, when there are no collection, the message in the empty pane has overflown the width. I fixed it by adding `white-space: normal;` in the `.Constellation_empty` selector (BTW, there is are 2 partially overriding entries for it in the css).

PS,
The rest of the changes in the css file were whitespace autofixes by my editor I did not notice until now.
